### PR TITLE
basic cross platform CMake build and Linux build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ _ReSharper*/
 *.aux
 *.bbl
 *.blg
+
+#  VSCode ignores
+*.vscode

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ The `FLIP.sln` solution contains one CUDA backend project and one pure C++ backe
 
 Compiling the CUDA project requires a CUDA compatible GPU. Instruction on how to install CUDA can be found [here](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html).
 
+Alternatively, a CMake build can be done by creating a build directory and invoking CMake on the source `cpp` dir:
+
+```
+mkdir build
+cd build
+cmake ../cpp
+cmake --build .
+```
+
+CUDA support is enabled via the `FLIP_ENABLE_CUDA`, which can be passed to CMake on the command line with
+`-DFLIP_ENABLE_CUDA=ON` or set interactively with `ccmake` or `cmake-gui`.
+
 **Usage:**
 ```
 flip[-cuda].exe --reference reference.{exr|png} --test test.{exr|png} [options]

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,50 @@
+###########################################################################
+# Copyright(c) 2020 - 2021, NVIDIA CORPORATION.All rights reserved.
+#
+# Redistributionand use in sourceand binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met :
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditionsand the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditionsand the following disclaimer in the
+#    documentationand /or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES(INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###########################################################################
+
+cmake_minimum_required(VERSION 3.9)
+
+set(CMAKE_DISABLE_SOURCE_CHANGES ON)
+set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_BUILD_TYPE_INIT "Release")
+
+project(flip LANGUAGES CXX)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+include(GNUInstallDirs)
+
+option(FLIP_ENABLE_CUDA "Include CUDA version of flip" OFF)
+
+add_subdirectory(CPP)
+if (FLIP_ENABLE_CUDA)
+  add_subdirectory(CUDA)
+endif()

--- a/cpp/CPP/CMakeLists.txt
+++ b/cpp/CPP/CMakeLists.txt
@@ -1,0 +1,35 @@
+###########################################################################
+# Copyright(c) 2020 - 2021, NVIDIA CORPORATION.All rights reserved.
+#
+# Redistributionand use in sourceand binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met :
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditionsand the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditionsand the following disclaimer in the
+#    documentationand /or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES(INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###########################################################################
+
+add_executable(${PROJECT_NAME} ../common/FLIP.cpp)
+target_include_directories(${PROJECT_NAME}
+PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}
+  ${CMAKE_CURRENT_LIST_DIR}/../common
+)
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/cpp/CPP/color.h
+++ b/cpp/CPP/color.h
@@ -199,7 +199,7 @@ namespace FLIP
 
         static inline color3 sqrt(color3 v)
         {
-            return color3(std::sqrtf(v.x), std::sqrtf(v.y), std::sqrtf(v.z));
+            return color3(std::sqrt(v.x), std::sqrt(v.y), std::sqrt(v.z));
         }
 
         static inline color3 clamp(color3 v, float _min = 0.0f, float _max = 1.0f)
@@ -359,8 +359,8 @@ namespace FLIP
 
         static inline float HyAB(color3& refPixel, color3& testPixel)
         {
-            float cityBlockDistanceL = std::fabsf(refPixel.x - testPixel.x);
-            float euclideanDistanceAB = std::sqrtf((refPixel.y - testPixel.y) * (refPixel.y - testPixel.y) + (refPixel.z - testPixel.z) * (refPixel.z - testPixel.z));
+            float cityBlockDistanceL = std::fabs(refPixel.x - testPixel.x);
+            float euclideanDistanceAB = std::sqrt((refPixel.y - testPixel.y) * (refPixel.y - testPixel.y) + (refPixel.z - testPixel.z) * (refPixel.z - testPixel.z));
             return cityBlockDistanceL + euclideanDistanceAB;
         }
 

--- a/cpp/CPP/image.h
+++ b/cpp/CPP/image.h
@@ -132,23 +132,23 @@ namespace FLIP
 
         static float GaussSum(const float x2, const float a1, const float b1, const float a2, const float b2)
         {
-            const float pi = float(M_PI);
-            const float pi_sq = float(M_PI * M_PI);
-            return a1 * std::sqrtf(pi / b1) * std::expf(-pi_sq * x2 / b1) + a2 * std::sqrtf(pi / b2) * std::expf(-pi_sq * x2 / b2);
+            const float pi = float(PI);
+            const float pi_sq = float(PI * PI);
+            return a1 * std::sqrt(pi / b1) * std::exp(-pi_sq * x2 / b1) + a2 * std::sqrt(pi / b2) * std::exp(-pi_sq * x2 / b2);
         }
 
         static float Gaussian(const float x, const float y, const float sigma)
         {
-            return std::expf(-(x * x + y * y) / (2.0f * sigma * sigma));
+            return std::exp(-(x * x + y * y) / (2.0f * sigma * sigma));
         }
 
         static int calculateSpatialFilterRadius(const float ppd)
         {
             const float deltaX = 1.0f / ppd;
-            const float pi_sq = float(M_PI * M_PI);
+            const float pi_sq = float(PI * PI);
 
             float maxScaleParameter = std::max(std::max(std::max(GaussianConstants.b1.x, GaussianConstants.b1.y), std::max(GaussianConstants.b1.z, GaussianConstants.b2.x)), std::max(GaussianConstants.b2.y, GaussianConstants.b2.z));
-            int radius = int(std::ceil(3.0f * std::sqrtf(maxScaleParameter / (2.0f * pi_sq)) * ppd)); // Set radius based on largest scale parameter
+            int radius = int(std::ceil(3.0f * std::sqrt(maxScaleParameter / (2.0f * pi_sq)) * ppd)); // Set radius based on largest scale parameter
 
             return radius;
         }
@@ -364,17 +364,17 @@ namespace FLIP
             {
                 for (int x = 0; x < this->getWidth(); x++)
                 {
-                    const float normalizationFactor = 1.0f / std::sqrtf(2.0f);
+                    const float normalizationFactor = 1.0f / std::sqrt(2.0f);
 
                     color3 er = edgeReference.get(x, y);
                     color3 et = edgeTest.get(x, y);
                     color3 pr = pointReference.get(x, y);
                     color3 pt = pointTest.get(x, y);
 
-                    const float edgeValueRef = std::sqrtf(er.x * er.x + er.y * er.y);
-                    const float edgeValueTest = std::sqrtf(et.x * et.x + et.y * et.y);
-                    const float pointValueRef = std::sqrtf(pr.x * pr.x + pr.y * pr.y);
-                    const float pointValueTest = std::sqrtf(pt.x * pt.x + pt.y * pt.y);
+                    const float edgeValueRef = std::sqrt(er.x * er.x + er.y * er.y);
+                    const float edgeValueTest = std::sqrt(et.x * et.x + et.y * et.y);
+                    const float pointValueRef = std::sqrt(pr.x * pr.x + pr.y * pr.y);
+                    const float pointValueTest = std::sqrt(pt.x * pt.x + pt.y * pt.y);
 
                     const float edgeDifference = std::abs(edgeValueRef - edgeValueTest);
                     const float pointDifference = std::abs(pointValueRef - pointValueTest);
@@ -406,7 +406,7 @@ namespace FLIP
 
         void expose(float level)
         {
-            float m = std::powf(2.0f, level);
+            float m = std::pow(2.0f, level);
             for (int y = 0; y < this->getHeight(); y++)
             {
                 for (int x = 0; x < this->getWidth(); x++)

--- a/cpp/CPP/tensor.h
+++ b/cpp/CPP/tensor.h
@@ -93,7 +93,7 @@ namespace FLIP
         struct { int x, y, z; };
     };
 
-    const float M_PI = 3.14159265358979f;
+    const float PI = 3.14159265358979f;
 
     template<typename T = color3>
     class tensor

--- a/cpp/CUDA/CMakeLists.txt
+++ b/cpp/CUDA/CMakeLists.txt
@@ -1,0 +1,38 @@
+###########################################################################
+# Copyright(c) 2020 - 2021, NVIDIA CORPORATION.All rights reserved.
+#
+# Redistributionand use in sourceand binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met :
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditionsand the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditionsand the following disclaimer in the
+#    documentationand /or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES(INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###########################################################################
+
+project(flip-cuda LANGUAGES CXX CUDA)
+
+add_executable(${PROJECT_NAME} ../common/FLIP.cpp)
+target_include_directories(${PROJECT_NAME}
+PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}
+  ${CMAKE_CURRENT_LIST_DIR}/../common
+)
+set_source_files_properties(../common/FLIP.cpp PROPERTIES LANGUAGE CUDA)
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/cpp/CUDA/color.cuh
+++ b/cpp/CUDA/color.cuh
@@ -203,7 +203,7 @@ namespace FLIP
 
         __host__ __device__ static inline color3 sqrt(color3 v)
         {
-            return color3(std::sqrtf(v.x), std::sqrtf(v.y), std::sqrtf(v.z));
+            return color3(std::sqrt(v.x), std::sqrt(v.y), std::sqrt(v.z));
         }
 
         __host__ __device__ static inline color3 clamp(color3 v, float _min = 0.0f, float _max = 1.0f)
@@ -363,8 +363,8 @@ namespace FLIP
 
         __host__ __device__ static inline float HyAB(color3& refPixel, color3& testPixel)
         {
-            float cityBlockDistanceL = std::fabsf(refPixel.x - testPixel.x);
-            float euclideanDistanceAB = std::sqrtf((refPixel.y - testPixel.y) * (refPixel.y - testPixel.y) + (refPixel.z - testPixel.z) * (refPixel.z - testPixel.z));
+            float cityBlockDistanceL = std::fabs(refPixel.x - testPixel.x);
+            float euclideanDistanceAB = std::sqrt((refPixel.y - testPixel.y) * (refPixel.y - testPixel.y) + (refPixel.z - testPixel.z) * (refPixel.z - testPixel.z));
             return cityBlockDistanceL + euclideanDistanceAB;
         }
 

--- a/cpp/CUDA/cudaKernels.cuh
+++ b/cpp/CUDA/cudaKernels.cuh
@@ -283,17 +283,17 @@ namespace FLIP
 
         if (x >= dim.x || y >= dim.y || z >= dim.z) return;
 
-        const float normalizationFactor = 1.0f / std::sqrtf(2.0f);
+        const float normalizationFactor = 1.0f / std::sqrt(2.0f);
 
         color3 er = pEdgeReference[i];
         color3 et = pEdgeTest[i];
         color3 pr = pPointReference[i];
         color3 pt = pPointTest[i];
 
-        const float edgeValueRef = std::sqrtf(er.x * er.x + er.y * er.y);
-        const float edgeValueTest = std::sqrtf(et.x * et.x + et.y * et.y);
-        const float pointValueRef = std::sqrtf(pr.x * pr.x + pr.y * pr.y);
-        const float pointValueTest = std::sqrtf(pt.x * pt.x + pt.y * pt.y);
+        const float edgeValueRef = std::sqrt(er.x * er.x + er.y * er.y);
+        const float edgeValueTest = std::sqrt(et.x * et.x + et.y * et.y);
+        const float pointValueRef = std::sqrt(pr.x * pr.x + pr.y * pr.y);
+        const float pointValueTest = std::sqrt(pt.x * pt.x + pt.y * pt.y);
 
         const float edgeDifference = std::abs(edgeValueRef - edgeValueTest);
         const float pointDifference = std::abs(pointValueRef - pointValueTest);
@@ -438,17 +438,17 @@ namespace FLIP
 
         if (x >= dim.x || y >= dim.y || z >= dim.z) return;
 
-        const float normalizationFactor = 1.0f / std::sqrtf(2.0f);
+        const float normalizationFactor = 1.0f / std::sqrt(2.0f);
 
         color3 er = pEdgeReference[i];
         color3 et = pEdgeTest[i];
         color3 pr = pPointReference[i];
         color3 pt = pPointTest[i];
 
-        const float edgeValueRef = std::sqrtf(er.x * er.x + er.y * er.y);
-        const float edgeValueTest = std::sqrtf(et.x * et.x + et.y * et.y);
-        const float pointValueRef = std::sqrtf(pr.x * pr.x + pr.y * pr.y);
-        const float pointValueTest = std::sqrtf(pt.x * pt.x + pt.y * pt.y);
+        const float edgeValueRef = std::sqrt(er.x * er.x + er.y * er.y);
+        const float edgeValueTest = std::sqrt(et.x * et.x + et.y * et.y);
+        const float pointValueRef = std::sqrt(pr.x * pr.x + pr.y * pr.y);
+        const float pointValueTest = std::sqrt(pt.x * pt.x + pt.y * pt.y);
 
         const float edgeDifference = std::abs(edgeValueRef - edgeValueTest);
         const float pointDifference = std::abs(pointValueRef - pointValueTest);

--- a/cpp/CUDA/cudaTensor.cuh
+++ b/cpp/CUDA/cudaTensor.cuh
@@ -86,7 +86,7 @@ namespace FLIP
 
 namespace FLIP
 {
-    const float M_PI = 3.14159265358979f;
+    const float PI = 3.14159265358979f;
 
     const dim3 DEFAULT_KERNEL_BLOCK_DIM = { 32, 32, 1 };  //  1.2s
 

--- a/cpp/common/FLIP.cpp
+++ b/cpp/common/FLIP.cpp
@@ -65,7 +65,7 @@ struct
 //  Pixels per degree (PPD)
 inline float calculatePPD(const float dist, const float resolutionX, const float monitorWidth)
 {
-    return dist * (resolutionX / monitorWidth) * (float(FLIP::M_PI) / 180.0f);
+    return dist * (resolutionX / monitorWidth) * (float(FLIP::PI) / 180.0f);
 }
 
 inline std::string f2s(float value, size_t decimals = 4)
@@ -258,7 +258,7 @@ int main(int argc, char** argv)
                 ss << std::string(exposure < 0.0f ? "m" : "p") << std::to_string(std::abs(exposure));
                 std::string expString = ss.str();
 
-                rImage.copy(referenceImage);    
+                rImage.copy(referenceImage);
                 tImage.copy(testImage);
 
                 rImage.expose(exposure);

--- a/cpp/common/filename.h
+++ b/cpp/common/filename.h
@@ -324,7 +324,11 @@ namespace FLIP
             std::stringstream ss;
             if (this->mDirectory != "")
             {
+#if _WIN32
                 ss << this->mDirectory << "\\";
+#else
+                ss << this->mDirectory << "/";
+#endif
             }
             ss << this->mName;
             if (this->mIsNumbered)
@@ -355,7 +359,11 @@ namespace FLIP
             std::stringstream ss;
             if (this->mDirectory != "")
             {
+#if _WIN32
                 ss << this->mDirectory << "\\";
+#else
+                ss << this->mDirectory << "/";
+#endif
             }
             ss << this->mName;
             if (this->mIsNumbered)


### PR DESCRIPTION
Hi! I just finished a Linux port that might be worth sharing because I wanted to try out flip for some stuff I'm doing, but almost exclusively work on Linux. I'm very comfortable with CMake, so I ended up writing a minimal CMake build to build both `flip` and `flip-cuda`. 

Here's what is in this MR:

- CMake scripts that:
    - require C++11
    - build the `flip` executable
    - provide an option `FLIP_ENABLE_CUDA`, which when turned on builds `flip-cuda` using CMake's built-in CUDA support
    - install `flip` (and `flip-cuda`) into `CMAKE_INSTALL_PREFIX`/bin via `make install`
    - in theory this build is 100% cross-platform, but I have only tried it on Ubuntu 21.04...there are no platform-specific parts to it
- Use C++ overload-based version of math functions in `std::`
    - For some reason gcc doesn't seem to include the precision-specific math functions in the `std::` namespace. I chose to use the generic versions which are overloaded based on the operand instead (this ends up calling the same thing in the end).
- `M_PI` as an identifier name collides with a macro definition of the value from the gcc standard library, so I renamed it to just `PI`.
- FLIP::filename using `\` to divide paths and final file name caused issues on Linux
    - I conditionally compiled this based on platform (`#ifdef _WIN32`) to keep Windows behavior constant (not sure if this matters)
- The definition of `image::FLIP()` needed to be moved below other functions to ensure declaration ordering is satisfied (MSVC appears to be more permissive here)
- README edits to mention that CMake is a build option for C++/CUDA

Note that I did not change anything wrt the VS project files, so existing users should not be affected.

I'm happy to revise per anyone's request.

Cheers,
Jeff