### PR TITLE
[CPP] Fixed Bug due to uninitialized Memory

### DIFF
--- a/cpp/common/FLIP.cpp
+++ b/cpp/common/FLIP.cpp
@@ -281,7 +281,7 @@ int main(int argc, char** argv)
         FLIP::image<FLIP::color3> testImage(testFileName.toString());
 
         FLIP::image<FLIP::color3> viridisMap(FLIP::MapViridis, 256);
-        FLIP::image<float> errorMapFLIP(referenceImage.getWidth(), referenceImage.getHeight());
+        FLIP::image<float> errorMapFLIP(referenceImage.getWidth(), referenceImage.getHeight(), 0.0f);
 
         auto t0 = std::chrono::high_resolution_clock::now();
         auto t = t0;
@@ -289,7 +289,7 @@ int main(int argc, char** argv)
         {
             FLIP::image<FLIP::color3> rImage(referenceImage.getWidth(), referenceImage.getHeight());
             FLIP::image<FLIP::color3> tImage(referenceImage.getWidth(), referenceImage.getHeight());
-            FLIP::image<float> tmpErrorMap(referenceImage.getWidth(), referenceImage.getHeight());
+            FLIP::image<float> tmpErrorMap(referenceImage.getWidth(), referenceImage.getHeight(), 0.0f);
             FLIP::image<float> prevTmpErrorMap(referenceImage.getWidth(), referenceImage.getHeight());
 
             FLIP::image<float> maxErrorExposureMap(referenceImage.getWidth(), referenceImage.getHeight());


### PR DESCRIPTION
I noticed that on an M1 Max the computed results (both the mean and the output images) for exr input files had a 50/50 chance of being wrong. After looking through the code I noticed that the setMaxExposure function only conditionally sets the "errorMap"  and "this" pixel values.

Initializing errorMapFLIP and tmpErrorMap with 0 values fixes the problem.