### PR TITLE
Fix CUDA build (Ubuntu 22.04, CUDA 11.8)

### DIFF
--- a/cpp/CUDA/cudaImage.cuh
+++ b/cpp/CUDA/cudaImage.cuh
@@ -144,7 +144,7 @@ namespace FLIP
             filterYCx.synchronizeDevice();
             filterCz.synchronizeDevice();
             FLIP::kernelSpatialFilterFirstDir << <intermediateYCxImageReference.getGridDim(), intermediateYCxImageReference.getBlockDim() >> > (intermediateYCxImageReference.mvpDeviceData, intermediateCzImageReference.mvpDeviceData, referenceImage.mvpDeviceData, intermediateYCxImageTest.mvpDeviceData, intermediateCzImageTest.mvpDeviceData, testImage.mvpDeviceData, filterYCx.mvpDeviceData, filterCz.mvpDeviceData, intermediateYCxImageReference.mDim, filterYCx.mDim); // Filter sizes are the same.
-            checkStatus("kernelSpatialFilterFirstDir");
+            image<T>::checkStatus("kernelSpatialFilterFirstDir");
             intermediateYCxImageReference.setState(CudaTensorState::DEVICE_ONLY);
             intermediateCzImageReference.setState(CudaTensorState::DEVICE_ONLY);
             intermediateYCxImageTest.setState(CudaTensorState::DEVICE_ONLY);
@@ -166,7 +166,7 @@ namespace FLIP
             const float pccmax = FLIPConstants.gpc * cmax;
 
             FLIP::kernelSpatialFilterSecondDirAndColorDifference << <colorDifferenceImage.getGridDim(), colorDifferenceImage.getBlockDim() >> > (colorDifferenceImage.mvpDeviceData, intermediateYCxImageReference.mvpDeviceData, intermediateCzImageReference.mvpDeviceData, intermediateYCxImageTest.mvpDeviceData, intermediateCzImageTest.mvpDeviceData, filterYCx.mvpDeviceData, filterCz.mvpDeviceData, colorDifferenceImage.mDim, filterYCx.mDim, cmax, pccmax); // Filter sizes are the same.
-            checkStatus("kernelSpatialFilterSecondDirAndColorDifference");
+            image<T>::checkStatus("kernelSpatialFilterSecondDirAndColorDifference");
             colorDifferenceImage.setState(CudaTensorState::DEVICE_ONLY);
         }
 

--- a/cpp/common/sharedflip.h
+++ b/cpp/common/sharedflip.h
@@ -10,8 +10,9 @@ namespace FLIP
 {
     const float PI = 3.14159265358979f;
 
-    static const struct
+    static const struct xFLIPConstants
     {
+        xFLIPConstants() = default;
         float gqc = 0.7f;
         float gpc = 0.4f;
         float gpt = 0.95f;
@@ -19,8 +20,9 @@ namespace FLIP
         float gqf = 0.5f;
     } FLIPConstants;
 
-    static const struct
+    static const struct xGaussianConstants
     {
+        xGaussianConstants() = default;
         color3 a1 = { 1.0f, 1.0f, 34.1f };
         color3 b1 = { 0.0047f, 0.0053f, 0.04f };
         color3 a2 = { 0.0f, 0.0f, 13.5f };


### PR DESCRIPTION
This fixes the following warnings/errors, which I saw when building flip with CUDA support on Ubuntu 22.04:

```
/home/mmp/src/flip/cpp/CUDA/../common/sharedflip.h(20): warning #811-D: const variable "FLIP::FLIPConstants" requires an initializer -- class "struct FLIP::<unnamed>" has no user-provided default constructor

/home/mmp/src/flip/cpp/CUDA/../common/sharedflip.h(28): warning #811-D: const variable "FLIP::GaussianConstants" requires an initializer -- class "struct FLIP::<unnamed>" has no user-provided default constructor

/home/mmp/src/flip/cpp/CUDA/cudaImage.cuh(147): error: identifier "checkStatus" is undefined
          detected during instantiation of "void FLIP::image<T>::FLIP(FLIP::image<FLIP::color3> &, FLIP::image<FLIP::color3> &, float) [with T=float]"
/home/mmp/src/flip/cpp/common/FLIP.cpp(342): here

/home/mmp/src/flip/cpp/CUDA/cudaImage.cuh(169): error: identifier "checkStatus" is undefined
          detected during instantiation of "void FLIP::image<T>::FLIP(FLIP::image<FLIP::color3> &, FLIP::image<FLIP::color3> &, float) [with T=float]"
/home/mmp/src/flip/cpp/common/FLIP.cpp(342): here
```
