### PR TITLE
Allow to build both library and executable with a single build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 include(GNUInstallDirs)
 
 option(FLIP_ENABLE_CUDA "Include CUDA version of flip" OFF)
-option(FLIP_LIBRARY OFF)
+option(FLIP_BUILD_TOOLS "Build command-line tools" ON)
 
 add_subdirectory(cpp/CPP)
 if (FLIP_ENABLE_CUDA)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ cmake --build .
 
 CUDA support is enabled via the `FLIP_ENABLE_CUDA`, which can be passed to CMake on the command line with
 `-DFLIP_ENABLE_CUDA=ON` or set interactively with `ccmake` or `cmake-gui`.
-`FLIP_LIBRARY` option allows to output a library rather than an executable.
+`FLIP_BUILD_TOOLS` option allows to output the `flip` executable in addition to the FLIP library.
 
 **Usage:**
 ```

--- a/cpp/CPP/CMakeLists.txt
+++ b/cpp/CPP/CMakeLists.txt
@@ -30,15 +30,23 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #################################################################################
 
-if (FLIP_LIBRARY)
-  add_library(${PROJECT_NAME} ../common/FLIP.cpp)
-else()
-  add_executable(${PROJECT_NAME} ../common/FLIP.cpp)
-endif()
+add_library(${PROJECT_NAME} ../common/FLIP.cpp)
 
 target_include_directories(${PROJECT_NAME}
 PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}
   ${CMAKE_CURRENT_LIST_DIR}/../common
 )
-install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+if(FLIP_BUILD_TOOLS)
+  add_executable(flip_cli ../common/FLIP.cpp)
+  target_include_directories(flip_cli
+    PRIVATE
+      ${CMAKE_CURRENT_LIST_DIR}
+      ${CMAKE_CURRENT_LIST_DIR}/../common
+  )
+  install(TARGETS flip_cli DESTINATION ${CMAKE_INSTALL_BINDIR})
+  set_property(TARGET flip_cli PROPERTY EXPORT_NAME "cli")
+  set_property(TARGET flip_cli PROPERTY OUTPUT_NAME "flip")
+endif()


### PR DESCRIPTION
This PR suggests some changes to the CMake setup to allow to build both FLIP library and executable in a single build.

The rationale why I chose to make the executable and not the library optional is because I am in the process of writing a port (i.e. a package) for `flip` to microsoft/vcpkg (cf. microsoft/vcpkg#36013).
In the context of (this) package manager, we usually create library by default, and then can optionally opt-in to create tool too.