### PR TITLE
Explicitly include <cstdint> for GCC 13 compatibility

### DIFF
--- a/cpp/tool/filename.h
+++ b/cpp/tool/filename.h
@@ -52,6 +52,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <string>
 #include <iostream>
 #include <sstream>

--- a/cpp/tool/pooling.h
+++ b/cpp/tool/pooling.h
@@ -53,6 +53,7 @@
 #include <cmath>
 #include <vector>
 #include <string>
+#include <cstdint>
 #include <sstream>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
GCC 13 no longer implicitly includes [some headers](https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes), including `<cstdint>` which contains `std::uint32_t`, so it should be explicitly included.