### PR TITLE
fix default argument mutation

### DIFF
--- a/python/flip/main.cpp
+++ b/python/flip/main.cpp
@@ -232,10 +232,11 @@ std::tuple<py::array_t<float>, float, py::dict> evaluate(const py::array_t<float
         }
     }
     delete flip;
+    
+    py::dict returnParams = {};
+    updateInputParameters(parameters, returnParams);
 
-    updateInputParameters(parameters, inputParameters);
-
-    return std::make_tuple(flipNumpy, meanError, inputParameters);
+    return std::make_tuple(flipNumpy, meanError, returnParams);
 }
 
 // Create command line, based on the Python command line string, for the FLIP tool to parse.


### PR DESCRIPTION
This PR fixes issue #32 

Instead of mutating the provided inputParameters, I populate a fresh `py::dict` with the parameters

I don't know if this is the best fix, but it worked for me.
