### PR TITLE
Add basic Bazel support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,55 @@
+#################################################################################
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+# SPDX-License-Identifier: BSD-3-Clause
+#################################################################################
+
+cc_library(
+    name = "flip",
+    hdrs = ["src/cpp/FLIP.h"],
+    includes = ["cpp"],
+    visibility = ["//visibility:public"],
+)
+
+cc_binary(
+    name = "flip-cli",
+    srcs = [
+        "src/cpp/tool/FLIP-tool.cpp",
+        "src/cpp/tool/FLIPToolHelpers.h",
+        "src/cpp/tool/commandline.h",
+        "src/cpp/tool/filename.h",
+        "src/cpp/tool/imagehelpers.h",
+        "src/cpp/tool/pooling.h",
+        "src/cpp/tool/stb_image.h",
+        "src/cpp/tool/stb_image_write.h",
+        "src/cpp/tool/tinyexr.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":flip"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,36 @@
+#################################################################################
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+# SPDX-License-Identifier: BSD-3-Clause
+#################################################################################
+
+module(
+    name = "flip",
+    compatibility_level = 1,
+)


### PR DESCRIPTION
This PR helps users of the [Bazel](https://bazel.build/) build system to integrate flip in their builds.

Supporting two build systems (CMake and Bazel) is of course more effort to maintain but helps to spread flip.
In the worst case the Bazel build does simply not work - in the best case, someone who uses Bazel can benefit from it.
The Bazel build files will not influence the CMake build, and can coexist without any side effects. 

Also, other projects support CMake and Bazel side by side (e.g. [Catch2](https://github.com/catchorg/Catch2), [GoogleTest](https://github.com/google/googletest), [OpenEXR](https://github.com/AcademySoftwareFoundation/openexr), [oneTBB](https://github.com/uxlfoundation/oneTBB) etc.)

I am willing to support the Bazel build of this lib for at least a half a year.

Seems that also NVIDIA uses internally at some projects Bazel (e.g. https://github.com/NVIDIA/bluebazel)

In the case Bazel is installed flip-cli can be runned via:

```
bazel run //:flip-cli -- --help
```